### PR TITLE
add kicad6 support

### DIFF
--- a/src/pages/2-core/1-utility.md
+++ b/src/pages/2-core/1-utility.md
@@ -125,7 +125,7 @@ General parameters:
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | <nobr>`connection.timeout`</nobr> | integer (ms) | 5000 | Maximum connection timeout for component description loading from [remote repository](/library/) |
-| `output` | string | 'kicad' | Output library format. The supported outputs are: `'kicad'`, `'geda'`, `'coraleda'`  |
+| `output` | string | 'kicad' | Output library format. The supported outputs are: `'kicad'`, `'kicad6'`, `'geda'`, `'coraleda'` |
 
 Schematic symbol related parameters:
 


### PR DESCRIPTION
KiCad 6 has a different symbol library file format than KiCad < 6